### PR TITLE
Skip the pdf build when the pdf target is excluded

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,3 +180,21 @@ sed turpis imperdiet eleifend sit amet id sapien.
 ```
 <sup><a href='/src/Tests/Samples.VerifyPdf.verified.txt#L1-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-Samples.VerifyPdf.verified.txt' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+
+## Exclude the pdf
+
+The source pdf is included in the snapshot as a `.verified.pdf`. Where committing it is not wanted, [`ExcludeTargets`](https://github.com/VerifyTests/Verify/blob/main/docs/converter.md#excluding-targets) drops it from a verification and skips normalizing it, while the info and text still verify:
+
+<!-- snippet: ExcludePdf -->
+<a id='snippet-ExcludePdf'></a>
+```cs
+[Test]
+public Task ExcludePdf() =>
+    VerifyFile("sample.pdf")
+        .ExcludeTargets("pdf");
+```
+<sup><a href='/src/Tests/Samples.cs#L21-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExcludePdf' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+To exclude the pdf for every test, call `VerifierSettings.ExcludeTargets("pdf")` at initialization.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;NU1608;NU1109</NoWarn>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,12 +11,12 @@
     <PackageVersion Include="PdfPig" Version="0.1.15" />
     <PackageVersion Include="Polyfill" Version="10.11.2" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.174" />
-    <PackageVersion Include="Verify" Version="31.22.0" />
+    <PackageVersion Include="Verify" Version="31.24.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.3.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.22.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.24.0" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Argon" Version="0.35.0" />
-    <PackageVersion Include="DiffEngine" Version="19.3.1" />
+    <PackageVersion Include="DiffEngine" Version="19.3.2" />
     <PackageVersion Include="EmptyFiles" Version="8.18.2" />
     <PackageVersion Include="SimpleInfoName" Version="3.2.0" />
   </ItemGroup>

--- a/src/Tests/Samples.ExcludePdf.verified.txt
+++ b/src/Tests/Samples.ExcludePdf.verified.txt
@@ -1,0 +1,158 @@
+﻿{
+  Information: {
+    Creator: Writer,
+    Producer: LibreOffice 4.2,
+    CreationDate: DateTimeOffset_1
+  },
+  PageCount: 4,
+  Pages: [
+    {
+      Size: A4,
+      Text:
+Lorem ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing
+elit. Nunc ac faucibus odio.
+
+Vestibulum neque massa, scelerisque sit amet ligula eu, congue molestie mi. Praesent ut
+varius sem. Nullam at porttitor arcu, nec lacinia nisi. Ut ac dolor vitae odio interdum
+condimentum. Vivamus dapibus sodales ex, vitae malesuada ipsum cursus
+convallis. Maecenas sed egestas nulla, ac condimentum orci. Mauris diam felis,
+vulputate ac suscipit et, iaculis non est. Curabitur semper arcu ac ligula semper, nec luctus
+nisl blandit. Integer lacinia ante ac libero lobortis imperdiet. Nullam mollis convallis ipsum,
+ac accumsan nunc vehicula vitae. Nulla eget justo in felis tristique fringilla. Morbi sit amet
+tortor quis risus auctor condimentum. Morbi in ullamcorper elit. Nulla iaculis tellus sit amet
+mauris tempus fringilla.
+
+Maecenas mauris lectus, lobortis et purus mattis, blandit dictum tellus.
+
+ Maecenas non lorem quis tellus placerat varius.
+
+ Nulla facilisi.
+
+ Aenean congue fringilla justo ut aliquam.
+
+ Mauris id ex erat. Nunc vulputate neque vitae justo facilisis, non condimentum ante
+sagittis.
+
+ Morbi viverra semper lorem nec molestie.
+
+ Maecenas tincidunt est efficitur ligula euismod, sit amet ornare est vulputate.
+
+Row 1 Row 2 Row 3 Row 4
+0
+2
+4
+6
+8
+10
+12
+
+Column 1
+Column 2
+Column 3
+
+    },
+    {
+      Index: 1,
+      Size: A4,
+      Text:
+In non mauris justo. Duis vehicula mi vel mi pretium, a viverra erat efficitur. Cras aliquam
+est ac eros varius, id iaculis dui auctor. Duis pretium neque ligula, et pulvinar mi placerat
+et. Nulla nec nunc sit amet nunc posuere vestibulum. Ut id neque eget tortor mattis
+tristique. Donec ante est, blandit sit amet tristique vel, lacinia pulvinar arcu. Pellentesque
+scelerisque fermentum erat, id posuere justo pulvinar ut. Cras id eros sed enim aliquam
+lobortis. Sed lobortis nisl ut eros efficitur tincidunt. Cras justo mi, porttitor quis mattis vel,
+ultricies ut purus. Ut facilisis et lacus eu cursus.
+
+In eleifend velit vitae libero sollicitudin euismod. Fusce vitae vestibulum velit. Pellentesque
+vulputate lectus quis pellentesque commodo. Aliquam erat volutpat. Vestibulum in egestas
+velit. Pellentesque fermentum nisl vitae fringilla venenatis. Etiam id mauris vitae orci
+maximus ultricies.
+
+Cras fringilla ipsum magna, in fringilla dui commodo
+a.
+
+Lorem ipsum Lorem ipsum Lorem ipsum
+
+1 In eleifend velit vitae libero sollicitudin euismod. Lorem
+
+2 Cras fringilla ipsum magna, in fringilla dui commodo
+a.
+Ipsum
+
+3 Aliquam erat volutpat. Lorem
+
+4 Fusce vitae vestibulum velit. Lorem
+
+5 Etiam vehicula luctus fermentum. Ipsum
+
+Etiam vehicula luctus fermentum. In vel metus congue, pulvinar lectus vel, fermentum dui.
+Maecenas ante orci, egestas ut aliquet sit amet, sagittis a magna. Aliquam ante quam,
+pellentesque ut dignissim quis, laoreet eget est. Aliquam erat volutpat. Class aptent taciti
+sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Ut ullamcorper
+justo sapien, in cursus libero viverra eget. Vivamus auctor imperdiet urna, at pulvinar leo
+posuere laoreet. Suspendisse neque nisl, fringilla at iaculis scelerisque, ornare vel dolor. Ut
+et pulvinar nunc. Pellentesque fringilla mollis efficitur. Nullam venenatis commodo
+imperdiet. Morbi velit neque, semper quis lorem quis, efficitur dignissim ipsum. Ut ac lorem
+sed turpis imperdiet eleifend sit amet id sapien.
+
+    },
+    {
+      Index: 2,
+      Size: A4,
+      Text:
+Lorem ipsum dolor sit amet, consectetur adipiscing
+elit.
+
+Nunc ac faucibus odio. Vestibulum neque massa, scelerisque sit amet ligula eu, congue
+molestie mi. Praesent ut varius sem. Nullam at porttitor arcu, nec lacinia nisi. Ut ac dolor
+vitae odio interdum condimentum. Vivamus dapibus sodales ex, vitae malesuada ipsum
+cursus convallis. Maecenas sed egestas nulla, ac condimentum orci. Mauris diam felis,
+vulputate ac suscipit et, iaculis non est. Curabitur semper arcu ac ligula semper, nec luctus
+nisl blandit. Integer lacinia ante ac libero lobortis imperdiet. Nullam mollis convallis ipsum,
+ac accumsan nunc vehicula vitae. Nulla eget justo in felis tristique fringilla. Morbi sit amet
+tortor quis risus auctor condimentum. Morbi in ullamcorper elit. Nulla iaculis tellus sit amet
+mauris tempus fringilla.
+
+Maecenas mauris lectus, lobortis et purus mattis, blandit
+dictum tellus.
+
+Maecenas non lorem quis tellus placerat varius. Nulla facilisi. Aenean congue fringilla justo
+ut aliquam. Mauris id ex erat. Nunc vulputate neque vitae justo facilisis, non condimentum
+ante sagittis. Morbi viverra semper lorem nec molestie. Maecenas tincidunt est efficitur
+ligula euismod, sit amet ornare est vulputate.
+
+In non mauris justo. Duis vehicula mi vel mi pretium, a viverra erat efficitur. Cras aliquam
+est ac eros varius, id iaculis dui auctor. Duis pretium neque ligula, et pulvinar mi placerat
+et. Nulla nec nunc sit amet nunc posuere vestibulum. Ut id neque eget tortor mattis
+tristique. Donec ante est, blandit sit amet tristique vel, lacinia pulvinar arcu. Pellentesque
+scelerisque fermentum erat, id posuere justo pulvinar ut. Cras id eros sed enim aliquam
+lobortis. Sed lobortis nisl ut eros efficitur tincidunt. Cras justo mi, porttitor quis mattis vel,
+ultricies ut purus. Ut facilisis et lacus eu cursus.
+
+In eleifend velit vitae libero sollicitudin euismod.
+
+Fusce vitae vestibulum velit. Pellentesque vulputate lectus quis pellentesque commodo.
+Aliquam erat volutpat. Vestibulum in egestas velit. Pellentesque fermentum nisl vitae
+fringilla venenatis. Etiam id mauris vitae orci maximus ultricies. Cras fringilla ipsum
+magna, in fringilla dui commodo a.
+
+Etiam vehicula luctus fermentum. In vel metus congue, pulvinar lectus vel, fermentum dui.
+Maecenas ante orci, egestas ut aliquet sit amet, sagittis a magna. Aliquam ante quam,
+pellentesque ut dignissim quis, laoreet eget est. Aliquam erat volutpat. Class aptent taciti
+sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Ut ullamcorper
+justo sapien, in cursus libero viverra eget. Vivamus auctor imperdiet urna, at pulvinar leo
+posuere laoreet. Suspendisse neque nisl, fringilla at iaculis scelerisque, ornare vel dolor. Ut
+et pulvinar nunc. Pellentesque fringilla mollis efficitur. Nullam venenatis commodo
+imperdiet. Morbi velit neque, semper quis lorem quis, efficitur dignissim ipsum. Ut ac lorem
+sed turpis imperdiet eleifend sit amet id sapien.
+
+    },
+    {
+      Index: 3,
+      Size: A4,
+      Text: 
+    }
+  ]
+}

--- a/src/Tests/Samples.cs
+++ b/src/Tests/Samples.cs
@@ -17,4 +17,13 @@ public class Samples
         Verify(File.OpenRead("sample.pdf"), "pdf");
 
     #endregion
+
+    #region ExcludePdf
+
+    [Test]
+    public Task ExcludePdf() =>
+        VerifyFile("sample.pdf")
+            .ExcludeTargets("pdf");
+
+    #endregion
 }

--- a/src/Verify.PdfPig/VerifyPdfPig.cs
+++ b/src/Verify.PdfPig/VerifyPdfPig.cs
@@ -59,18 +59,21 @@ public static class VerifyPdfPig
         // The pdf snapshot is always the full source document, regardless of PagesToInclude:
         // PagesToInclude only trims the info/text pages, since PdfPig has no in-place page splitter
         // and rebuilding a subset via the writer would re-serialize the whole file.
-        //
-        // Neutralize the volatile fields for the pdf snapshot only once the document, which reads
-        // lazily from the same buffer, has been released.
-        PdfNormalizer.Normalize(bytes);
-        return new(
-            info,
-            [
+        List<Target> targets = [];
+        // Generating the pdf is expensive, so skip it entirely when the pdf target is excluded.
+        if (!context.IsTargetExcluded("pdf"))
+        {
+            // Neutralize the volatile fields for the pdf snapshot only once the document, which reads
+            // lazily from the same buffer, has been released.
+            PdfNormalizer.Normalize(bytes);
+            targets.Add(
                 new("pdf", new MemoryStream(bytes))
                 {
                     BypassComparersForSubsequentOnDifference = true
-                }
-            ]);
+                });
+        }
+
+        return new(info, targets);
     }
 
     static byte[] ToBytes(Stream stream)


### PR DESCRIPTION
The converter now checks context.IsTargetExcluded("pdf") and skips PdfNormalizer.Normalize plus the pdf target when the pdf is excluded via ExcludeTargets. The info and extracted text still verify. Adds an ExcludePdf sample and a readme section.